### PR TITLE
Update vod-push.js

### DIFF
--- a/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
+++ b/provider-utils/awscloudformation/service-walkthroughs/vod-push.js
@@ -411,7 +411,7 @@ async function createCDNEnvVars(context, options, resourceName, aws) {
   const { instance: envParamManager } = await ensureEnvParamManager(projectDetails.localEnvInfo.envName)
   envParamManager.getResourceParamManager('video', resourceName).setParams(cdnEnvConfigDetails)
 
-  await videoParamManager.save()
+  await envParamManager.save()
 }
 
 async function createCMS(context, apiName, props) {


### PR DESCRIPTION
Creation with CDN would fail with 'videoParamManager is not defined'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.